### PR TITLE
One fix and enable arbitrary size arrays in predict of platt/temp

### DIFF
--- a/src/detection_calibration/platt_scaling.py
+++ b/src/detection_calibration/platt_scaling.py
@@ -198,7 +198,7 @@ class PlattScaling(nn.Module):
         shift = self.shift.expand(logits.size())
         logits += shift
 
-        return np.array(torch.sigmoid(logits).item())
+        return torch.sigmoid(logits).detach().numpy()
 
 
 class TemperatureScaling(nn.Module):
@@ -359,6 +359,6 @@ class TemperatureScaling(nn.Module):
         temp = self.temperature.expand(logits.size())
         logits /= torch.abs(temp)
 
-        return np.array(torch.sigmoid(logits).item())
+        return torch.sigmoid(logits).detach().numpy()
 
 # Thanks to https://github.com/gpleiss/temperature_scaling/

--- a/src/detection_calibration/utils.py
+++ b/src/detection_calibration/utils.py
@@ -285,7 +285,7 @@ def linear_regression(classagnostic, calibration_info, is_dece=False):
             model[cl] = LinearRegression(positive=True).fit(
                 valid_scores, valid_labels)
 
-        return model
+    return model
 
 
 def platt_scaling(classagnostic, calibration_info, is_dece=False, use_grid_search=False, use_quality_focal_loss=False):


### PR DESCRIPTION
At linear regression there was a wrong indentation which caused one branch to not return the model.

Second thing enables passing arbitrary size tensors to predict, which is needed when using big datasets for evaluating the calibration method.

Closes #2 